### PR TITLE
typo: 'mvc' should be 'core'

### DIFF
--- a/docs/create-application.md
+++ b/docs/create-application.md
@@ -27,7 +27,7 @@ title: 创建一个工程
     <version>0.0.1</version>
 
     <properties>
-        <blade-mvc.version>2.1.1.RELEASE</blade-mvc.version>
+        <blade-core.version>2.1.1.RELEASE</blade-core.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
typo: 'mvc' should be 'core'